### PR TITLE
Update for PHP8.0 compatibility

### DIFF
--- a/classes/singleton.php
+++ b/classes/singleton.php
@@ -34,7 +34,7 @@ trait Singleton {
 	/**
 	 * Constructor protected from the outside
 	 */
-	final private function __construct() {
+	private function __construct() {
 		$this->init();
 	}
 
@@ -57,5 +57,5 @@ trait Singleton {
 	 *
 	 * @return void
 	 */
-	final private function __wakeup() {}
+	private function __wakeup() {}
 }


### PR DESCRIPTION
Private functions cannot be used with final as private is final by definition. Fixes warnings in PHP8

<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards).
- In case you introduced a new action or filter hook, please also include [inline documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php).
- Please provide tests, if you can.
-->

This pull request fixes issue #{id}.

It will apply the following changes :

* 
* 
* 
